### PR TITLE
Restore recursive file permission normalization following git reset/clean

### DIFF
--- a/pydash/Dash/GitHub.py
+++ b/pydash/Dash/GitHub.py
@@ -7,6 +7,7 @@
 
 import contextlib
 import fcntl
+import grp
 import hashlib
 import json
 import os
@@ -23,6 +24,8 @@ import time
 _DEPLOY_HASH = re.compile(r"^[0-9a-f]{40}$")
 _DEPLOY_BRANCH = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 _DEPLOY_RESULT_MAX_BYTES = 4096
+_DEPLOY_PERMISSION_MODE = 0o755
+_DEPLOY_PERMISSION_MAX_ENTRIES = 500000
 
 
 class _GitDeploymentError(Exception):
@@ -121,7 +124,11 @@ def _build_deployment_git_runner(repository, git_user):
 
     def run_git(stage, arguments, timeout_seconds):
         prefix = fetch_prefix if stage == "fetch" else owner_prefix
-        file_mode = "false" if stage == "fetch" else "true"
+
+        # Reset from Git's declared modes, then ignore the intentional all-0755
+        # deployment contract while checking for content changes.
+        file_mode = "false" if stage in ("fetch", "verify") else "true"
+
         command = [
             *prefix,
             "-c", "core.fileMode=" + file_mode,
@@ -156,6 +163,132 @@ def _build_deployment_git_runner(repository, git_user):
         return completed.stdout.strip()
 
     return run_git
+
+
+def _deployment_identity(git_user, git_group):
+    if (
+        type(git_group) is not str
+        or not git_group
+        or len(git_group) > 128
+        or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", git_group)
+    ):
+        raise _GitDeploymentError("validate", "InvalidGitGroup")
+
+    try:
+        target_user = pwd.getpwnam(git_user)
+    except KeyError:
+        raise _GitDeploymentError("validate", "InvalidGitUser") from None
+
+    try:
+        target_group = grp.getgrnam(git_group)
+    except KeyError:
+        raise _GitDeploymentError("validate", "InvalidGitGroup") from None
+
+    return target_user.pw_uid, target_group.gr_gid
+
+
+def _normalize_deployment_permissions(repository, user_id, group_id, deadline):
+    """Restore the web-root ownership and mode contract without following links."""
+
+    def walk_error(err):
+        raise err
+
+    def deployment_paths():
+        yield repository
+
+        for root, directories, files in os.walk(repository, onerror=walk_error):
+            for name in directories:
+                yield os.path.join(root, name)
+
+            for name in files:
+                yield os.path.join(root, name)
+
+    try:
+        for entry_count, path in enumerate(deployment_paths(), start=1):
+            if entry_count > _DEPLOY_PERMISSION_MAX_ENTRIES:
+                raise _GitDeploymentError("permissions", "EntryLimitExceeded")
+
+            if time.monotonic() >= deadline:
+                raise _GitDeploymentError("permissions", "TimeoutExpired")
+
+            path_stat = os.lstat(path)
+
+            if stat.S_ISLNK(path_stat.st_mode):
+                if path_stat.st_uid != user_id or path_stat.st_gid != group_id:
+                    os.chown(path, user_id, group_id, follow_symlinks=False)
+
+                verified_stat = os.lstat(path)
+
+                if verified_stat.st_uid != user_id or verified_stat.st_gid != group_id:
+                    raise _GitDeploymentError("permissions", "OwnershipMismatch")
+
+                continue
+
+            if not (stat.S_ISREG(path_stat.st_mode) or stat.S_ISDIR(path_stat.st_mode)):
+                if path_stat.st_uid != user_id or path_stat.st_gid != group_id:
+                    os.chown(path, user_id, group_id)
+
+                if stat.S_IMODE(path_stat.st_mode) != _DEPLOY_PERMISSION_MODE:
+                    os.chmod(path, _DEPLOY_PERMISSION_MODE)
+
+                verified_stat = os.lstat(path)
+
+                if (
+                    verified_stat.st_uid != user_id
+                    or verified_stat.st_gid != group_id
+                    or stat.S_IMODE(verified_stat.st_mode) != _DEPLOY_PERMISSION_MODE
+                ):
+                    raise _GitDeploymentError("permissions", "PermissionMismatch")
+
+                continue
+
+            flags = os.O_RDONLY
+
+            if stat.S_ISDIR(path_stat.st_mode) and hasattr(os, "O_DIRECTORY"):
+                flags |= os.O_DIRECTORY
+
+            if hasattr(os, "O_CLOEXEC"):
+                flags |= os.O_CLOEXEC
+
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+
+            descriptor = os.open(path, flags)
+
+            try:
+                opened_stat = os.fstat(descriptor)
+
+                if (
+                    opened_stat.st_dev != path_stat.st_dev
+                    or opened_stat.st_ino != path_stat.st_ino
+                ):
+                    raise _GitDeploymentError("permissions", "PathChanged")
+
+                if opened_stat.st_uid != user_id or opened_stat.st_gid != group_id:
+                    os.fchown(descriptor, user_id, group_id)
+
+                if stat.S_IMODE(opened_stat.st_mode) != _DEPLOY_PERMISSION_MODE:
+                    os.fchmod(descriptor, _DEPLOY_PERMISSION_MODE)
+
+                verified_stat = os.fstat(descriptor)
+
+                if (
+                    verified_stat.st_uid != user_id
+                    or verified_stat.st_gid != group_id
+                    or stat.S_IMODE(verified_stat.st_mode) != _DEPLOY_PERMISSION_MODE
+                ):
+                    raise _GitDeploymentError("permissions", "PermissionMismatch")
+            finally:
+                os.close(descriptor)
+
+    except _GitDeploymentError:
+        raise
+
+    except OSError as error:
+        raise _GitDeploymentError(
+            "permissions",
+            _safe_deployment_error_type(error),
+        ) from None
 
 
 @contextlib.contextmanager
@@ -233,6 +366,7 @@ def DeployGitRepository(
     git_user="ensomniac",
     lock_wait_seconds=10,
     git_runner=None,
+    git_group="psacln",
 ):
     """Deploy one fast-forward Git revision with bounded, sanitized output."""
 
@@ -241,6 +375,7 @@ def DeployGitRepository(
     try:
         repository = _validate_deployment_repository(repository)
         run_git = git_runner or _build_deployment_git_runner(repository, git_user)
+        user_id, group_id = _deployment_identity(git_user, git_group)
 
         current_stage = "lock"
         lock_started = time.monotonic()
@@ -298,6 +433,14 @@ def DeployGitRepository(
 
             current_stage = "clean"
             invoke("clean", ["clean", "-fd"], 15)
+
+            current_stage = "permissions"
+            _normalize_deployment_permissions(
+                repository,
+                user_id,
+                group_id,
+                command_deadline,
+            )
 
             current_stage = "verify"
             deployed_revision = invoke("verify", ["rev-parse", "HEAD"], 10)

--- a/pydash/Dash/tests/test_git_deploy.py
+++ b/pydash/Dash/tests/test_git_deploy.py
@@ -1,4 +1,5 @@
 import contextlib
+import grp
 import importlib
 import io
 import json
@@ -69,6 +70,10 @@ class GitDeploymentTest(unittest.TestCase):
     def current_user():
         return pwd.getpwuid(os.geteuid()).pw_name
 
+    @staticmethod
+    def current_group():
+        return grp.getgrgid(os.getegid()).gr_name
+
     def test_fast_forward_cleans_debris_and_preserves_ignored_files(self):
         with tempfile.TemporaryDirectory() as temporary_root:
             root = Path(temporary_root).resolve()
@@ -89,6 +94,7 @@ class GitDeploymentTest(unittest.TestCase):
                 str(deployed),
                 lock_root=str(locks),
                 git_user=self.current_user(),
+                git_group=self.current_group(),
             )
 
             self.assertTrue(result["ok"], result)
@@ -98,9 +104,22 @@ class GitDeploymentTest(unittest.TestCase):
             self.assertEqual((deployed / "tracked.txt").read_text(), "two\n")
             self.assertFalse((deployed / "untracked.txt").exists())
             self.assertEqual((deployed / "ignored.txt").read_text(), "preserve\n")
-            self.assertEqual(self.git(deployed, "status", "--porcelain"), "")
+            self.assertEqual(
+                stat.S_IMODE((deployed / "ignored.txt").stat().st_mode),
+                0o755,
+            )
+            self.assertEqual(
+                self.git(
+                    deployed,
+                    "-c",
+                    "core.fileMode=false",
+                    "status",
+                    "--porcelain",
+                ),
+                "",
+            )
 
-    def test_fast_forward_restores_tree_declared_file_modes(self):
+    def test_fast_forward_restores_deployment_permissions(self):
         with tempfile.TemporaryDirectory() as temporary_root:
             root = Path(temporary_root).resolve()
             _, publisher, deployed = self.repositories(root)
@@ -110,36 +129,71 @@ class GitDeploymentTest(unittest.TestCase):
             executable = publisher / "executable.sh"
             executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             executable.chmod(0o755)
-            self.git(publisher, "add", "executable.sh")
-            self.git(publisher, "commit", "-m", "Add executable")
+            unchanged = publisher / "unchanged.txt"
+            unchanged.write_text("unchanged\n", encoding="utf-8")
+            outside = root / "outside.txt"
+            outside.write_text("outside\n", encoding="utf-8")
+            outside.chmod(0o600)
+            (publisher / "outside-link.txt").symlink_to("../outside.txt")
+            self.git(
+                publisher,
+                "add",
+                "executable.sh",
+                "unchanged.txt",
+                "outside-link.txt",
+            )
+            self.git(publisher, "commit", "-m", "Add deployment fixtures")
             self.git(publisher, "push")
 
             first_result = GitHubModule.DeployGitRepository(
                 str(deployed),
                 lock_root=str(locks),
                 git_user=self.current_user(),
+                git_group=self.current_group(),
             )
             self.assertTrue(first_result["ok"], first_result)
 
-            (deployed / "tracked.txt").chmod(0o755)
+            (deployed / "tracked.txt").chmod(0o644)
             (deployed / "executable.sh").chmod(0o644)
-            self.assertNotEqual(self.git(deployed, "status", "--porcelain"), "")
+            (deployed / "unchanged.txt").chmod(0o644)
 
+            (publisher / "tracked.txt").write_text("two\n", encoding="utf-8")
             (publisher / "next.txt").write_text("next\n", encoding="utf-8")
-            self.git(publisher, "add", "next.txt")
-            self.git(publisher, "commit", "-m", "Advance different path")
+            self.git(publisher, "add", "tracked.txt", "next.txt")
+            self.git(publisher, "commit", "-m", "Advance deployment")
             self.git(publisher, "push")
 
             result = GitHubModule.DeployGitRepository(
                 str(deployed),
                 lock_root=str(locks),
                 git_user=self.current_user(),
+                git_group=self.current_group(),
             )
 
             self.assertTrue(result["ok"], result)
-            self.assertEqual(stat.S_IMODE((deployed / "tracked.txt").stat().st_mode), 0o644)
-            self.assertEqual(stat.S_IMODE((deployed / "executable.sh").stat().st_mode), 0o755)
-            self.assertEqual(self.git(deployed, "status", "--porcelain"), "")
+            for deployed_path in (
+                deployed / "tracked.txt",
+                deployed / "executable.sh",
+                deployed / "unchanged.txt",
+                deployed / "next.txt",
+            ):
+                with self.subTest(path=deployed_path.name):
+                    deployed_stat = deployed_path.stat()
+                    self.assertEqual(stat.S_IMODE(deployed_stat.st_mode), 0o755)
+                    self.assertEqual(deployed_stat.st_uid, os.geteuid())
+                    self.assertEqual(deployed_stat.st_gid, os.getegid())
+            self.assertTrue((deployed / "outside-link.txt").is_symlink())
+            self.assertEqual(stat.S_IMODE(outside.stat().st_mode), 0o600)
+            self.assertEqual(
+                self.git(
+                    deployed,
+                    "-c",
+                    "core.fileMode=false",
+                    "status",
+                    "--porcelain",
+                ),
+                "",
+            )
 
     def test_command_order_has_one_reset_and_one_clean(self):
         with tempfile.TemporaryDirectory() as temporary_root:
@@ -172,6 +226,7 @@ class GitDeploymentTest(unittest.TestCase):
                 lock_root=str(locks),
                 git_user=self.current_user(),
                 git_runner=runner,
+                git_group=self.current_group(),
             )
 
             self.assertTrue(result["ok"], result)
@@ -210,15 +265,18 @@ class GitDeploymentTest(unittest.TestCase):
             )
             runner("fetch", ["fetch", "origin", "main"], 10)
             runner("reset", ["reset", "--hard", "a" * 40], 10)
+            runner("verify", ["status", "--porcelain=v1"], 10)
 
         fetch_command = run.call_args_list[0].args[0]
         reset_command = run.call_args_list[1].args[0]
+        verify_command = run.call_args_list[2].args[0]
         self.assertEqual(fetch_command[0], "/usr/bin/git")
         self.assertEqual(reset_command[0], "owner-git")
         self.assertIn("safe.directory=/validated/repository", fetch_command)
         self.assertIn("safe.directory=/validated/repository", reset_command)
         self.assertIn("core.fileMode=false", fetch_command)
         self.assertIn("core.fileMode=true", reset_command)
+        self.assertIn("core.fileMode=false", verify_command)
 
     def test_relative_broad_and_symlinked_repositories_fail_before_git(self):
         with tempfile.TemporaryDirectory() as temporary_root:
@@ -263,6 +321,7 @@ class GitDeploymentTest(unittest.TestCase):
                     git_user=self.current_user(),
                     lock_wait_seconds=0,
                     git_runner=runner,
+                    git_group=self.current_group(),
                 )
 
             self.assertFalse(result["ok"])
@@ -294,6 +353,7 @@ class GitDeploymentTest(unittest.TestCase):
                 lock_root=str(root),
                 git_user=self.current_user(),
                 git_runner=runner,
+                git_group=self.current_group(),
             )
 
             self.assertFalse(result["ok"])
@@ -332,6 +392,7 @@ class GitDeploymentTest(unittest.TestCase):
                 lock_root=str(root),
                 git_user=self.current_user(),
                 git_runner=runner,
+                git_group=self.current_group(),
             )
 
             self.assertFalse(result["ok"])


### PR DESCRIPTION
This should fix the webhook file permission regression without undermining the recent deployment hardening.